### PR TITLE
feat: add support for detecting SELECT * in const and var declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ unqueryvet is a Go static analysis tool (linter) that detects `SELECT *` usage i
 ## Features
 
 - **Detects `SELECT *` in string literals** - Finds problematic queries in your Go code
+- **Constants and variables support** - Detects `SELECT *` in const and var declarations
 - **SQL Builder support** - Works with popular SQL builders like Squirrel, GORM, etc.
 - **Highly configurable** - Extensive configuration options for different use cases
 - **Supports `//nolint:unqueryvet`** - Standard Go linting suppression
@@ -78,6 +79,12 @@ linters:
 ### Problematic code (will trigger warnings)
 
 ```go
+// Constants with SELECT *
+const QueryUsers = "SELECT * FROM users"
+
+// Variables with SELECT *
+var QueryOrders = "SELECT * FROM orders"
+
 // String literals with SELECT *
 query := "SELECT * FROM users"
 rows, err := db.Query("SELECT * FROM orders WHERE status = ?", "active")
@@ -90,7 +97,13 @@ query := builder.Select().Columns("*").From("inventory")
 ### Good code (recommended)
 
 ```go
-// Explicit column selection
+// Constants with explicit columns
+const QueryUsers = "SELECT id, name, email FROM users"
+
+// Variables with explicit columns
+var QueryOrders = "SELECT id, status, total FROM orders"
+
+// String literals with explicit column selection
 query := "SELECT id, name, email FROM users"
 rows, err := db.Query("SELECT id, total FROM orders WHERE status = ?", "active")
 

--- a/_examples/testdata/example.go
+++ b/_examples/testdata/example.go
@@ -10,26 +10,84 @@ import (
 // ExampleBadCode shows patterns that Unqueryvet will warn about
 func ExampleBadCode() {
 	var db *sql.DB
-
-	// BAD: Direct SELECT * in string literal
-	// unqueryvet will warn about this
-	query1 := "SELECT * FROM users WHERE active = true"
-	_ = query1
 	_ = db // db would be used in real code
 
-	// BAD: SELECT * in function call
-	// unqueryvet will warn about this
+	// BAD: Package-level style constants with SELECT *
+	const (
+		queryUsers   = "SELECT * FROM users"
+		queryOrders  = "SELECT * FROM orders WHERE status = 'pending'"
+		queryComplex = `
+			SELECT * 
+			FROM products
+			WHERE price > 100
+			ORDER BY created_at DESC
+		`
+	)
+	_, _, _ = queryUsers, queryOrders, queryComplex
+
+	// BAD: Single constant with SELECT *
+	const querySingle = "SELECT * FROM inventory"
+	_ = querySingle
+
+	// BAD: Variables with SELECT *
+	var (
+		dynamicQuery = "SELECT * FROM logs WHERE date > NOW()"
+		configQuery  = "SELECT * FROM settings"
+	)
+	_, _ = dynamicQuery, configQuery
+
+	// BAD: Config-style constants
+	const (
+		getAllUsers    = "SELECT * FROM users"
+		getAllProducts = "SELECT * FROM products"
+		getAllOrders   = "SELECT * FROM orders"
+	)
+	_, _, _ = getAllUsers, getAllProducts, getAllOrders
+
+	// BAD: Local constant with SELECT *
+	const localBadQuery = "SELECT * FROM categories"
+	_ = localBadQuery
+
+	// BAD: Multiple local constants with SELECT *
+	const (
+		localQuery1 = "SELECT * FROM tags"
+		localQuery2 = "SELECT * FROM comments WHERE active = true"
+	)
+	_, _ = localQuery1, localQuery2
+
+	// BAD: Mixed declaration styles - all use SELECT *
+	const constQuery = "SELECT * FROM users"
+	var varQuery = "SELECT * FROM products"
+	shortQuery := "SELECT * FROM orders"
+	_, _, _ = constQuery, varQuery, shortQuery
+
+	// BAD: Direct SELECT * in string literal
+	query1 := "SELECT * FROM users WHERE active = true"
+	_ = query1
+
+	// BAD: SELECT * in function call argument
 	// In real code: rows, err := db.Query("SELECT * FROM products")
 	_ = "SELECT * FROM products"
 
 	// BAD: Multiline SELECT *
-	// unqueryvet will warn about this
 	multilineQuery := `
 		SELECT *
 		FROM orders
 		WHERE status = 'pending'
 	`
 	_ = multilineQuery
+
+	// BAD: Real-world example - query constants for single use
+	const (
+		getUsersQuery    = "SELECT * FROM users WHERE role = 'admin'"
+		getProductsQuery = "SELECT * FROM products WHERE in_stock = true"
+		getOrdersQuery   = "SELECT * FROM orders WHERE created_at > NOW() - INTERVAL '7 days'"
+	)
+	_, _, _ = getUsersQuery, getProductsQuery, getOrdersQuery
+
+	// BAD: SQL Builder patterns (pseudo-code)
+	// query := squirrel.Select("*").From("users")
+	// query := squirrel.Select().From("users")  // Empty Select defaults to SELECT *
 }
 
 // ExampleGoodCode shows patterns that Unqueryvet approves
@@ -37,11 +95,46 @@ func ExampleGoodCode() {
 	var db *sql.DB
 	_ = db // db would be used in real code
 
-	// GOOD: Explicit column selection
+	// GOOD: Package-level style constants with explicit columns
+	const (
+		goodQueryPackage   = "SELECT id, name, email FROM users"
+		countQueryPackage  = "SELECT COUNT(*) FROM users"
+		schemaQueryPackage = "SELECT * FROM information_schema.tables"
+	)
+	_, _, _ = goodQueryPackage, countQueryPackage, schemaQueryPackage
+
+	// GOOD: Not a SQL query
+	const messagePackage = "Use * for multiplication"
+	_ = messagePackage
+
+	// GOOD: Config-style constants with explicit columns
+	const (
+		getUserBasics   = "SELECT id, username, email FROM users"
+		getProductInfo  = "SELECT id, name, price, stock FROM products"
+		getOrderDetails = "SELECT id, user_id, total, status FROM orders"
+	)
+	_, _, _ = getUserBasics, getProductInfo, getOrderDetails
+
+	// GOOD: Local constant with explicit columns
+	const localGoodQuery = "SELECT id, name FROM categories"
+	_ = localGoodQuery
+
+	// GOOD: Multiple local constants with explicit columns
+	const (
+		goodLocalQuery1 = "SELECT id, name FROM tags"
+		goodLocalQuery2 = "SELECT id, text, author_id FROM comments WHERE active = true"
+	)
+	_, _ = goodLocalQuery1, goodLocalQuery2
+
+	// GOOD: Local constant with COUNT(*)
+	const localCountQuery = "SELECT COUNT(*) FROM sessions"
+	_ = localCountQuery
+
+	// GOOD: Explicit column selection in variable
 	query1 := "SELECT id, name, email FROM users WHERE active = true"
 	_ = query1
 
-	// GOOD: Specific columns in function call
+	// GOOD: Specific columns in function call argument
 	// In real code: rows, err := db.Query("SELECT id, name, price FROM products")
 	_ = "SELECT id, name, price FROM products"
 
@@ -60,6 +153,18 @@ func ExampleGoodCode() {
 	// GOOD: Information schema queries are allowed
 	schemaQuery := "SELECT * FROM information_schema.tables WHERE table_name = 'users'"
 	_ = schemaQuery
+
+	// GOOD: Real-world example - properly defined queries
+	const (
+		getUsersQueryGood    = "SELECT id, username, email, role FROM users WHERE role = 'admin'"
+		getProductsQueryGood = "SELECT id, name, price, stock FROM products WHERE in_stock = true"
+		getOrdersQueryGood   = "SELECT id, user_id, total, created_at FROM orders WHERE created_at > NOW() - INTERVAL '7 days'"
+	)
+	_, _, _ = getUsersQueryGood, getProductsQueryGood, getOrdersQueryGood
+
+	// GOOD: SQL Builder patterns (pseudo-code)
+	// query := squirrel.Select("id", "name", "email").From("users")
+	// query := squirrel.Select().Columns("id", "name").From("users")
 }
 
 // ExampleSuppression shows how to suppress Unqueryvet warnings
@@ -67,29 +172,22 @@ func ExampleSuppression() {
 	var db *sql.DB
 	_ = db // db would be used in real code
 
-	// Using nolint directive to suppress warning
+	// Using nolint directive to suppress warning for variable
 	debugQuery := "SELECT * FROM debug_logs" //nolint:unqueryvet
 	_ = debugQuery
 
-	// Alternative: use for temporary debugging
-	// Remove before committing
-	tempQuery := "SELECT * FROM temp_table" //nolint:unqueryvet // temporary for debugging
+	// Using nolint directive for constant
+	const tempQuery = "SELECT * FROM temp_table" //nolint:unqueryvet
 	_ = tempQuery
-}
 
-// ExampleSQLBuilders shows SQL builder patterns
-func ExampleSQLBuilders() {
-	// Pseudo-code examples (requires actual SQL builder libraries)
+	// Using nolint directive for multiple constants
+	const (
+		debugConst = "SELECT * FROM backup"    //nolint:unqueryvet
+		tempConst  = "SELECT * FROM temp_data" //nolint:unqueryvet // temporary for debugging
+	)
+	_, _ = debugConst, tempConst
 
-	// BAD: SELECT * in SQL builder
-	// query := squirrel.Select("*").From("users")
-
-	// BAD: Empty Select defaults to SELECT *
-	// query := squirrel.Select().From("users")
-
-	// GOOD: Explicit columns in SQL builder
-	// query := squirrel.Select("id", "name", "email").From("users")
-
-	// GOOD: Using Columns method
-	// query := squirrel.Select().Columns("id", "name").From("users")
+	// Using nolint for package-level style variable
+	var tempVar = "SELECT * FROM staging" //nolint:unqueryvet
+	_ = tempVar
 }

--- a/internal/analyzer/testdata/src/a/a.go
+++ b/internal/analyzer/testdata/src/a/a.go
@@ -8,6 +8,48 @@ import (
 	"os"
 )
 
+// Package-level constants with SELECT * (should trigger warnings)
+const (
+	// Should trigger warning - SELECT * in const
+	BadQuery1 = "SELECT * FROM users" // want "avoid SELECT \\* - explicitly specify needed columns for better performance, maintainability and stability"
+
+	// Should trigger warning - SELECT * with WHERE
+	BadQuery2 = "SELECT * FROM orders WHERE status = 'active'" // want "avoid SELECT \\* - explicitly specify needed columns for better performance, maintainability and stability"
+
+	// Good query - explicit columns
+	GoodQuery1 = "SELECT id, name, email FROM users"
+
+	// Good query - COUNT(*)
+	GoodQuery2 = "SELECT COUNT(*) FROM users"
+
+	// Good query - system tables
+	GoodQuery3 = "SELECT * FROM information_schema.tables"
+)
+
+// Single package-level const declaration
+const SingleBadQuery = "SELECT * FROM products" // want "avoid SELECT \\* - explicitly specify needed columns for better performance, maintainability and stability"
+
+const SingleGoodQuery = "SELECT id, name FROM products"
+
+// Multiline query constant
+const MultilineQuery = `SELECT * FROM inventory WHERE quantity > 0` // want "avoid SELECT \\* - explicitly specify needed columns for better performance, maintainability and stability"
+
+// Package-level variables (should also be checked)
+var (
+	VarBadQuery  = "SELECT * FROM categories" // want "avoid SELECT \\* - explicitly specify needed columns for better performance, maintainability and stability"
+	VarGoodQuery = "SELECT id, name FROM categories"
+	VarCount     = "SELECT COUNT(*) FROM categories"
+)
+
+// Non-SQL constants (should not trigger warnings)
+const (
+	NotSQL      = "This is not * a SQL query"
+	AlsoNotSQL  = "Use asterisk * in documentation"
+	JustText    = "Some random * text"
+	NumberValue = 42
+	BoolValue   = true
+)
+
 // Basic SELECT * detection in string literals
 func basicSelectStar() {
 	query := "SELECT * FROM users"           // want "avoid SELECT \\* - explicitly specify needed columns for better performance, maintainability and stability"
@@ -61,7 +103,7 @@ func defaultBehavior() {
 	_, _ = os.Open("file.sql")
 }
 
-// Test data for removed nolint functionality  
+// Test data for removed nolint functionality
 func removedNolintDirectives() {
 	// This now triggers - nolint support removed
 	query := "SELECT * FROM temp_table" // want "avoid SELECT \\* - explicitly specify needed columns for better performance, maintainability and stability"


### PR DESCRIPTION
## Summary

Adds support for detecting `SELECT *` usage in `const` and `var` declarations at package and function levels.

## Problem

Previously, the analyzer only detected `SELECT *` in:
- Short variable declarations: `query := "SELECT * FROM users"`
- Function call arguments: `db.Query("SELECT * FROM users")`

But missed a common pattern of storing SQL queries in constants:

```go
const UserQuery = "SELECT * FROM users"  // ❌ Not detected
var OrderQuery = "SELECT * FROM orders"  // ❌ Not detected
```

## Solution

### Core Changes

- Added `checkGenDecl()` function to process `*ast.GenDecl` nodes (const/var declarations)
- Integrated into both entry points: `run()` and `RunWithConfig()`
- Now detects:
  - ✅ Package-level constants: `const Query = "SELECT * FROM users"`
  - ✅ Package-level variables: `var Query = "SELECT * FROM users"`
  - ✅ Declaration blocks: `const (...)` and `var (...)`
  - ✅ Local constants inside functions

### Documentation Updates

- Updated README.md with new feature description
- Added examples for constants and variables

## Examples

### ❌ Will be detected:

```go
const QueryUsers = "SELECT * FROM users"
var DynamicQuery = "SELECT * FROM logs"

const (
    GetAllUsers = "SELECT * FROM users"
    GetOrders   = "SELECT * FROM orders"
)

func example() {
    const localQuery = "SELECT * FROM categories"
}
```

### ✅ Good practices:

```go
const GoodQuery = "SELECT id, name, email FROM users"
const CountQuery = "SELECT COUNT(*) FROM users"
const SchemaQuery = "SELECT * FROM information_schema.tables"
```

## Technical Details

### AST Analysis confirms no duplication:

- **`checkAssignStmt`** handles `*ast.AssignStmt`: short declarations (`:=`) and assignments (`=`)
- **`checkGenDecl`** (new) handles `*ast.GenDecl`: `const` and `var` declarations
- Functions are complementary with no overlap